### PR TITLE
Fix default editor behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@
 1. **Install the Extension:**  
    Search for `XLF Editor` in the VS Code Marketplace or install from [here](https://marketplace.visualstudio.com/).
 
-2. **Open an XLF File:**  
-   Right-click any `.xlf` file and select **Open With > XLF Translator**.
+2. **Open an XLF File:**
+   The extension does not automatically replace the default text editor. Right-click
+   any `.xlf` file and select **Open With > XLF Translator** or run the command
+   **"XLF Editor: Open XLF File"** from the palette.
 
 3. **Use the Command Palette:**  
    - `XLF Editor: Open XLF File`

--- a/xlf-editor/CHANGELOG.md
+++ b/xlf-editor/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.1] - 2025-06-23
+
+### Changed
+- The custom editor is now optional and no longer becomes the default for `.xlf`
+  files on first use.
+
 ## [1.1.0] - 2025-06-06
 
 ### Fixed

--- a/xlf-editor/README.md
+++ b/xlf-editor/README.md
@@ -48,8 +48,10 @@
 1. **Install the Extension:**  
    Search for `XLF Editor` in the VS Code Marketplace or install from [here](https://marketplace.visualstudio.com/).
 
-2. **Open an XLF File:**  
-   Right-click any `.xlf` file and select **Open With > XLF Translator**.
+2. **Open an XLF File:**
+   The extension does not automatically replace the default text editor. Right-click
+   any `.xlf` file and select **Open With > XLF Translator** or run the command
+   **"XLF Editor: Open XLF File"** from the palette.
 
 3. **Use the Command Palette:**  
    - `XLF Editor: Open XLF File`

--- a/xlf-editor/package.json
+++ b/xlf-editor/package.json
@@ -2,7 +2,7 @@
   "name": "xlf-editor",
   "displayName": "XLF Editor",
   "description": "Editor for XLF translation files in Business Central",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "DaJan404",
   "repository": {
     "type": "git",
@@ -53,7 +53,7 @@
             "filenamePattern": "*.xlf"
           }
         ],
-        "priority": "default"
+        "priority": "option"
       }
     ],
     "configuration": {


### PR DESCRIPTION
## Summary
- avoid becoming the default editor for `.xlf` files
- document optional editor usage
- bump version to 1.1.1 and update changelog

## Testing
- `npm run lint`
- `npm test` *(fails: `vscode-test: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_685991ad14888333a1f8b05e5a3941ce